### PR TITLE
Use external function for event listeners

### DIFF
--- a/template/pages/index.vue
+++ b/template/pages/index.vue
@@ -36,12 +36,17 @@
         return
       }
       this.online = Boolean(window.navigator.onLine)
-      this._offline_listener = window.addEventListener('offline', () => this.online = false)
-      this._online_listener = window.addEventListener('online', () => this.online = true)
+      window.addEventListener('offline', this._toggleNetworkStatus)
+      window.addEventListener('online', this._toggleNetworkStatus)
+    },
+    methods: {
+      _toggleNetworkStatus ({ type }) {
+        this.online = type === 'online'
+      }
     },
     destroyed () {
-      window.removeEventListener('offline', this._offline_listener)
-      window.removeEventListener('online', this._online_listener)
+      window.removeEventListener('offline', this._toggleNetworkStatus)
+      window.removeEventListener('online', this._toggleNetworkStatus)
     }
   }
 </script>


### PR DESCRIPTION
[According to W3](https://www.w3schools.com/jsref/met_element_removeeventlistener.asp):

> To remove event handlers, the function specified with the addEventListener() method must be an external function.
>
> Anonymous functions will not work.

`window.addEventListener` returns nothing (making `this._offline_listener == undefined`), so making this change to use an existing, external function which we can refer to later when destroying the component.

I _think_ this works better...