### PR TITLE
Requiring es6-promise ^4.1.1 to fix server error

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
+    "es6-promise": "^4.1.1",
     "eslint": "^3.15.0",
     "eslint-config-standard": "^6.2.1",
     "eslint-loader": "^1.6.1",


### PR DESCRIPTION
On install, I ran into `Error: Cannot find module 'es6-promise\auto'` just like the stacktrace [here](https://github.com/nuxt/nuxt.js/issues/1225#issuecomment-319034453).

Per [this response](https://github.com/nuxt/nuxt.js/issues/1225#issuecomment-320781687), adding  `"es6-promise": "^4.1.1",` to devDependencies fixed the problem.